### PR TITLE
Basic CSV import/export and data table

### DIFF
--- a/data/csv-simple-search-sample-data.csv
+++ b/data/csv-simple-search-sample-data.csv
@@ -1,0 +1,5 @@
+State,City,Type,Name,Diversity,Website,Phone #,Source
+NY,New York,Open Source Community,DevProgress,MBE Certified,"http://devprogress.us
+",(555)555-5555,DevProgress.us
+NV,Las Vegas,Catering,Lucky's Tasty Viddles,,http://luckystastyviddl.es,(777)777-7777,DNC
+NC,Raleigh,Flowers,Rollywood Florists,MBE Certfied,http://RollywoodFlowers.com,(123)456-7890,HfA

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "babel-polyfill": "^6.9.1",
     "normalize.css": "^4.1.1",
+    "papaparse": "^4.1.2",
+    "raw-loader": "^0.5.1",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "whatwg-fetch": "^1.0.0"

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -1,0 +1,70 @@
+import React from 'react';
+
+export default class DataTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      page: 0
+    };
+  }
+
+  prevPage() {
+    var prev = this.state.page - 1;
+    this.setState({
+      page: prev < 0 ? 0 : prev
+    });
+  }
+
+  nextPage() {
+    var props  = this.props,
+        limit  = props.limit,
+        length = props.values.length,
+        page = this.state.page,
+        next = page + 1;
+
+    this.setState({
+      page: next > Math.ceil(length / limit) ? page : next
+    });
+  }
+
+  render() {
+    var props = this.props,
+        limit = props.limit,
+        page  = this.state.page,
+        start = page * limit,
+        end = start + limit,
+        values  = props.values.slice(start, end),
+        columns = Object.keys(values[0]);
+
+    return (
+      <div>
+        <table>
+          <thead>
+            <tr>
+              {columns.map((col, i) => <th key={i}>{col}</th>)}
+            </tr>
+          </thead>
+
+          <tbody>
+            {values.map((val, i) => (
+              <tr key={i}>
+                {columns.map((col, j) => <td key={j}>{val[col]}</td>)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div className="pager">
+          <a onClick={this.prevPage.bind(this)}>&larr;</a>
+
+          <a onClick={this.nextPage.bind(this)}>&rarr;</a>
+        </div>
+      </div>
+    )
+  }
+}
+
+DataTable.propTypes = {
+  limit: React.PropTypes.number.isRequired,
+  values: React.PropTypes.array.isRequired
+};

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -9,14 +9,14 @@ export default class DataTable extends React.Component {
   }
 
   prevPage() {
-    var prev = this.state.page - 1;
+    let prev = this.state.page - 1;
     this.setState({
       page: prev < 0 ? 0 : prev
     });
   }
 
   nextPage() {
-    var props  = this.props,
+    let props  = this.props,
         limit  = props.limit,
         length = props.values.length,
         page = this.state.page,
@@ -28,7 +28,7 @@ export default class DataTable extends React.Component {
   }
 
   render() {
-    var props = this.props,
+    let props = this.props,
         limit = props.limit,
         page  = this.state.page,
         start = page * limit,

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -1,5 +1,8 @@
 import React from 'react';
+import Papa  from 'papaparse';
+import DataTable from './DataTable';
 import '../styles.css';
+import csvdata from '../../data/csv-simple-search-sample-data.csv';
 
 const propTypes = {
 
@@ -9,13 +12,29 @@ export default class MainView extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      data: this.import(csvdata)
     };
+  }
+
+  import(csv) {
+    var results = Papa.parse(csv, {
+      header: true,
+      dynamicTyping: true
+    });
+
+    if (results.errors.length) {
+      results.errors.forEach((err) => console.error(err));
+    }
+
+    return results.data;
   }
 
   render() {
     return (
       <div>
         Hello DevProgress!
+
+        <DataTable limit={20} values={this.state.data} />
       </div>
     );
   }

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -17,7 +17,7 @@ export default class MainView extends React.Component {
   }
 
   import(csv) {
-    var results = Papa.parse(csv, {
+    let results = Papa.parse(csv, {
       header: true,
       dynamicTyping: true
     });
@@ -29,12 +29,32 @@ export default class MainView extends React.Component {
     return results.data;
   }
 
+  export(json) {
+    let csv  = Papa.unparse(json),
+        blob = new Blob([csv], {type: 'text/csv'}),
+        url  = window.URL.createObjectURL(blob),
+        link = document.createElement('a'),
+        evt  = document.createEvent('MouseEvents');
+
+    link.setAttribute('href', url);
+    link.setAttribute('target', '_blank');
+    link.setAttribute('download', 'data.csv');
+
+    evt.initMouseEvent('click', true, true, document.defaultView, 1, 0, 0, 0, 0,
+      false, false, false, false, 0, null);
+    link.dispatchEvent(evt);
+  }
+
   render() {
+    let data = this.state.data;
+
     return (
       <div>
         Hello DevProgress!
 
-        <DataTable limit={20} values={this.state.data} />
+        <DataTable limit={20} values={data} />
+
+        <a onClick={this.export.bind(this, data)}>Export to CSV</a>
       </div>
     );
   }

--- a/webpack.make.js
+++ b/webpack.make.js
@@ -130,6 +130,11 @@ module.exports = function makeWebpackConfig(options) {
     {
       test: /\.json$/,
       loader: "json-loader"
+    },
+    {
+      // Allow us to load CSV files as strings.
+      test: /\.csv$/,
+      loader: "raw-loader"
     }
   ]}
 


### PR DESCRIPTION
This PR introduces initial skeleton code for us to iterate from. Functionality includes:
- import a packaged CSV file using webpack's [raw-loader](https://github.com/webpack/raw-loader). Possibly switch it to file-loader (@alexyaseen?). 
- parse it to JSON using [Papaparse](http://papaparse.com/).
- construct a simple paginated HTML table with configurable limit. 
- export JSON data to CSV and trigger a file download.
