### PR TITLE
Convert values to strings before calling toLowerCase.

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -15,7 +15,7 @@ export default class Search extends React.Component {
     var value = e.target.value;
     this.props.onFilteredData(_.filter(this.props.data, function (row) {
       return _.find(_.values(row), function (val) {
-        return (val.toLowerCase()).indexOf(value.toLowerCase()) !== -1;
+        return (val.toString().toLowerCase()).indexOf(value.toLowerCase()) !== -1;
       });
     }));
   }


### PR DESCRIPTION
When searching CSV files that have numeric columns, I get the following error on any search.

`Uncaught TypeError: val.toLowerCase is not a function`

This fixes that by converting all values to strings before doing a string search.
